### PR TITLE
fix: prevent failure during result nesting migration

### DIFF
--- a/revisions/__snapshots__/rev_7emq1brv0zz6_nest_analysis_results_field.ambr
+++ b/revisions/__snapshots__/rev_7emq1brv0zz6_nest_analysis_results_field.ambr
@@ -80,5 +80,32 @@
       }),
       'workflow': 'aodp',
     }),
+    dict({
+      '_id': 'missing',
+      'join_histogram': list([
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]),
+      'joined_pair_count': 12345,
+      'remainder_pair_count': 54321,
+      'workflow': 'aodp',
+    }),
+    dict({
+      '_id': 'none',
+      'join_histogram': list([
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]),
+      'joined_pair_count': 12345,
+      'remainder_pair_count': 54321,
+      'results': None,
+      'workflow': 'aodp',
+    }),
   ])
 # ---


### PR DESCRIPTION
Update the query to make sure `results` fields with missing or `null` values are ignored.