### PR TITLE
feat: create all mongo indexes

### DIFF
--- a/revisions/__snapshots__/rev_l20h8fsbbb28_create_all_database_indexes.ambr
+++ b/revisions/__snapshots__/rev_l20h8fsbbb28_create_all_database_indexes.ambr
@@ -1,0 +1,339 @@
+# name: test_upgrade
+  list([
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'created_at_-1': dict({
+        'key': list([
+          tuple(
+            'created_at',
+            -1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'key_1_sample.id_1': dict({
+        'key': list([
+          tuple(
+            'key',
+            1,
+          ),
+          tuple(
+            'sample.id',
+            1,
+          ),
+        ]),
+        'unique': True,
+        'v': 2,
+      }),
+      'sample.id_1': dict({
+        'key': list([
+          tuple(
+            'sample.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'name_1': dict({
+        'key': list([
+          tuple(
+            'name',
+            1,
+          ),
+        ]),
+        'sparse': True,
+        'unique': True,
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'created_at_1': dict({
+        'key': list([
+          tuple(
+            'created_at',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'index.id_1': dict({
+        'key': list([
+          tuple(
+            'index.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'otu.id_1': dict({
+        'key': list([
+          tuple(
+            'otu.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'otu.name_1': dict({
+        'key': list([
+          tuple(
+            'otu.name',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'otu.version_-1': dict({
+        'key': list([
+          tuple(
+            'otu.version',
+            -1,
+          ),
+        ]),
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'version_1_reference.id_1': dict({
+        'key': list([
+          tuple(
+            'version',
+            1,
+          ),
+          tuple(
+            'reference.id',
+            1,
+          ),
+        ]),
+        'unique': True,
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'id_1': dict({
+        'key': list([
+          tuple(
+            'id',
+            1,
+          ),
+        ]),
+        'unique': True,
+        'v': 2,
+      }),
+      'user.id_1': dict({
+        'key': list([
+          tuple(
+            'user.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      '_id_1_isolate.id_1': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+          tuple(
+            'isolate.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'abbreviation_1': dict({
+        'key': list([
+          tuple(
+            'abbreviation',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'name_1': dict({
+        'key': list([
+          tuple(
+            'name',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'nickname_1': dict({
+        'key': list([
+          tuple(
+            'nickname',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'reference.id_1_remote.id_1': dict({
+        'key': list([
+          tuple(
+            'reference.id',
+            1,
+          ),
+          tuple(
+            'remote.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'created_at_-1': dict({
+        'key': list([
+          tuple(
+            'created_at',
+            -1,
+          ),
+        ]),
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'name_1': dict({
+        'key': list([
+          tuple(
+            'name',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'otu_id_1': dict({
+        'key': list([
+          tuple(
+            'otu_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'reference.id_1_remote.id_1': dict({
+        'key': list([
+          tuple(
+            'reference.id',
+            1,
+          ),
+          tuple(
+            'remote.id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+    }),
+    dict({
+      '_id_': dict({
+        'key': list([
+          tuple(
+            '_id',
+            1,
+          ),
+        ]),
+        'v': 2,
+      }),
+      'b2c_oid_1': dict({
+        'key': list([
+          tuple(
+            'b2c_oid',
+            1,
+          ),
+        ]),
+        'sparse': True,
+        'unique': True,
+        'v': 2,
+      }),
+      'handle_1': dict({
+        'key': list([
+          tuple(
+            'handle',
+            1,
+          ),
+        ]),
+        'sparse': True,
+        'unique': True,
+        'v': 2,
+      }),
+    }),
+  ])
+# ---

--- a/revisions/rev_l20h8fsbbb28_create_all_database_indexes.py
+++ b/revisions/rev_l20h8fsbbb28_create_all_database_indexes.py
@@ -1,0 +1,114 @@
+"""
+Create all database indexes
+
+Revision ID: l20h8fsbbb28
+Date: 2023-01-31 00:56:11.597898
+
+"""
+import asyncio
+
+import arrow
+from motor.motor_asyncio import AsyncIOMotorClientSession, AsyncIOMotorDatabase
+from pymongo import DESCENDING, ASCENDING, IndexModel
+
+# Revision identifiers.
+name = "Create all database indexes"
+created_at = arrow.get("2023-01-31 00:56:11.597898")
+revision_id = "l20h8fsbbb28"
+
+
+async def upgrade(motor_db: AsyncIOMotorDatabase, session: AsyncIOMotorClientSession):
+    """
+    Create all database indexes.
+
+    This was formerly done on application startup. It did not make sense to do this
+    everytime the application started when new indexes are rarely introduced.
+    """
+    await motor_db.analyses.create_indexes(
+        [
+            IndexModel([("sample.id", ASCENDING)]),
+            IndexModel([("created_at", DESCENDING)]),
+            IndexModel([("key", ASCENDING), ("sample.id", ASCENDING)], unique=True),
+        ],
+        session=session,
+    )
+
+    await motor_db.groups.create_index(
+        "name", unique=True, sparse=True, session=session
+    )
+
+    await motor_db.history.create_indexes(
+        [
+            IndexModel([("otu.id", ASCENDING)]),
+            IndexModel([("index.id", ASCENDING)]),
+            IndexModel([("created_at", ASCENDING)]),
+            IndexModel([("otu.name", ASCENDING)]),
+            IndexModel([("otu.version", DESCENDING)]),
+        ],
+        session=session,
+    )
+
+    await motor_db.indexes.create_index(
+        [("version", ASCENDING), ("reference.id", ASCENDING)],
+        unique=True,
+        session=session,
+    )
+
+    await motor_db.keys.create_indexes(
+        [
+            IndexModel([("id", ASCENDING)], unique=True),
+            IndexModel([("user.id", ASCENDING)]),
+        ],
+        session=session,
+    )
+
+    await motor_db.otus.create_indexes(
+        [
+            IndexModel([("_id", ASCENDING), ("isolate.id", ASCENDING)]),
+            IndexModel([("name", ASCENDING)]),
+            IndexModel([("nickname", ASCENDING)]),
+            IndexModel([("abbreviation", ASCENDING)]),
+            IndexModel([("reference.id", ASCENDING), ("remote.id", ASCENDING)]),
+        ],
+        session=session,
+    )
+
+    await motor_db.samples.create_index([("created_at", DESCENDING)], session=session)
+
+    await motor_db.sequences.create_indexes(
+        [
+            IndexModel([("otu_id", ASCENDING)]),
+            IndexModel([("name", ASCENDING)]),
+            IndexModel([("reference.id", ASCENDING), ("remote.id", ASCENDING)]),
+        ],
+        session=session,
+    )
+
+    await motor_db.users.create_indexes(
+        [
+            IndexModel([("b2c_oid", ASCENDING)], unique=True, sparse=True),
+            IndexModel([("handle", ASCENDING)], unique=True, sparse=True),
+        ],
+        session=session,
+    )
+
+
+async def test_upgrade(mongo, snapshot):
+    async with await mongo.client.start_session() as session:
+        async with session.start_transaction():
+            await upgrade(mongo, session)
+
+    assert (
+        await asyncio.gather(
+            mongo.analyses.index_information(),
+            mongo.groups.index_information(),
+            mongo.history.index_information(),
+            mongo.indexes.index_information(),
+            mongo.keys.index_information(),
+            mongo.otus.index_information(),
+            mongo.samples.index_information(),
+            mongo.sequences.index_information(),
+            mongo.users.index_information(),
+        )
+        == snapshot
+    )


### PR DESCRIPTION
Create MongoDB indexes in a migration instead of in application code.

This will require the migrations to applied to the desired revision before the application can be run properly. If the migration is not applied, key indexes will be missing.