### PR TITLE
feat: add space field to mongo resources

### DIFF
--- a/revisions/__snapshots__/rev_s607ucxpct81_add_space_field.ambr
+++ b/revisions/__snapshots__/rev_s607ucxpct81_add_space_field.ambr
@@ -1,0 +1,114 @@
+# name: test_upgrade
+  list([
+    list([
+      dict({
+        '_id': 'foo',
+        'space': dict({
+          'id': 2,
+        }),
+      }),
+      dict({
+        '_id': 'bar',
+        'space': 0,
+      }),
+      dict({
+        '_id': 'baz',
+        'space': dict({
+          'id': 15,
+        }),
+      }),
+      dict({
+        '_id': 'noo',
+        'space': 0,
+      }),
+    ]),
+    list([
+      dict({
+        '_id': 'foo',
+        'space': dict({
+          'id': 2,
+        }),
+      }),
+      dict({
+        '_id': 'bar',
+        'space': 0,
+      }),
+      dict({
+        '_id': 'baz',
+        'space': dict({
+          'id': 15,
+        }),
+      }),
+      dict({
+        '_id': 'noo',
+        'space': 0,
+      }),
+    ]),
+    list([
+      dict({
+        '_id': 'foo',
+        'space': dict({
+          'id': 2,
+        }),
+      }),
+      dict({
+        '_id': 'bar',
+        'space': 0,
+      }),
+      dict({
+        '_id': 'baz',
+        'space': dict({
+          'id': 15,
+        }),
+      }),
+      dict({
+        '_id': 'noo',
+        'space': 0,
+      }),
+    ]),
+    list([
+      dict({
+        '_id': 'foo',
+        'space': dict({
+          'id': 2,
+        }),
+      }),
+      dict({
+        '_id': 'bar',
+        'space': 0,
+      }),
+      dict({
+        '_id': 'baz',
+        'space': dict({
+          'id': 15,
+        }),
+      }),
+      dict({
+        '_id': 'noo',
+        'space': 0,
+      }),
+    ]),
+    list([
+      dict({
+        '_id': 'foo',
+        'space': dict({
+          'id': 2,
+        }),
+      }),
+      dict({
+        '_id': 'bar',
+        'space': 0,
+      }),
+      dict({
+        '_id': 'baz',
+        'space': dict({
+          'id': 15,
+        }),
+      }),
+      dict({
+        '_id': 'noo',
+        'space': 0,
+      }),
+    ]),
+  ])
+# ---

--- a/revisions/rev_s607ucxpct81_add_space_field.py
+++ b/revisions/rev_s607ucxpct81_add_space_field.py
@@ -1,0 +1,70 @@
+"""
+Add space field
+
+Revision ID: s607ucxpct81
+Date: 2023-02-08 00:06:52.287448
+
+"""
+import asyncio
+
+import arrow
+from motor.motor_asyncio import AsyncIOMotorClientSession, AsyncIOMotorDatabase
+
+# Revision identifiers.
+name = "Add space field"
+created_at = arrow.get("2023-02-08 00:06:52.287448")
+revision_id = "s607ucxpct81"
+
+
+async def upgrade(motor_db: AsyncIOMotorDatabase, session: AsyncIOMotorClientSession):
+    for collection in (
+        motor_db.analyses,
+        motor_db.jobs,
+        motor_db.references,
+        motor_db.samples,
+        motor_db.subtractions,
+    ):
+        await collection.update_many(
+            {"space": {"$exists": False}}, {"$set": {"space": 0}}, session=session
+        )
+
+
+async def test_upgrade(mongo, snapshot):
+    collections = (
+        mongo.analyses,
+        mongo.jobs,
+        mongo.references,
+        mongo.samples,
+        mongo.subtractions,
+    )
+
+    for collection in collections:
+        await collection.insert_many(
+            [
+                {
+                    "_id": "foo",
+                    "space": {"id": 2},
+                },
+                {
+                    "_id": "bar",
+                },
+                {
+                    "_id": "baz",
+                    "space": {"id": 15},
+                },
+                {
+                    "_id": "noo",
+                },
+            ]
+        )
+
+    async with await mongo.client.start_session() as session:
+        async with session.start_transaction():
+            await upgrade(mongo, session)
+
+    assert (
+        await asyncio.gather(
+            *[collection.find().to_list(None) for collection in collections]
+        )
+        == snapshot
+    )


### PR DESCRIPTION
Adds the `space` field to analyses, jobs, refs, samples, and subtractions.

The field looks like:
```
{
  "space": {
    "id": 0
  }
}
```
The default value is the default space id: `0`.